### PR TITLE
Adding docs and support for ember fastboot 1.0.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,26 @@ ember install ember-cli-videojs-shim
 import videojs from 'videojs';
 ```
 
-## Features & Todos
+## Settings
+Video.js ships with a number of supported languages. To import languages add:
 
-- [x] ES6 accessible module for videojs
-- [ ] FastBoot support
-- [ ] Plugin support
+```javascript
+...
+    'videojs': {
+      'languages': [
+        'ar'
+      ],
+    }
+...
+```
+
+To your ember-cli-build.js file.
 
 ## License
 
 ember-cli-videojs-shim shims is [MIT Licensed](https://github.com/joshuairl/ember-cli-videojs-shim/blob/master/LICENSE.md).
 
 [embadge]: http://embadge.io/
-[ember-badge]: http://embadge.io/v1/badge.svg?start=1.0.0
+[ember-badge]: http://embadge.io/v1/badge.svg?start=2.4.0
 [npm]: https://www.npmjs.org/package/ember-cli-videojs-shim
 [npm-badge]: https://img.shields.io/npm/v/ember-cli-videojs-shim.svg?style=flat-square

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,7 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
-    // Add options here
+
   });
 
   /*
@@ -13,6 +13,7 @@ module.exports = function(defaults) {
     This build file does *not* influence how the addon or the app using it
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
+
 
   return app.toTree();
 };

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 const path = require('path');
 const Funnel = require('broccoli-funnel');
 const MergeTrees = require('broccoli-merge-trees');
+const map = require('broccoli-stew').map;
 
 module.exports = {
   name: 'videojs',
@@ -11,7 +12,6 @@ module.exports = {
   included: function(app) {
     this._super.included.apply(this, arguments);
 
-    if (!process.env.EMBER_CLI_FASTBOOT) {
       let options = app.options.videojs || {};
 
       app.import({
@@ -40,7 +40,6 @@ module.exports = {
       });
 
       app.import(path.join('vendor/video-js.swf'), { destDir: 'assets' });
-    }
   },
 
   treeForVendor(vendorTree) {
@@ -50,9 +49,9 @@ module.exports = {
       trees.push(vendorTree);
     }
 
-    trees.push(
-      new Funnel(path.join(path.dirname(require.resolve('video.js'))))
-    );
+    let videojsLib = new Funnel(path.join(path.dirname(require.resolve('video.js'))));
+    videojsLib = map(videojsLib, (content) => `if (typeof FastBoot === 'undefined') { ${content} }`);
+    trees.push(videojsLib);
 
     return new MergeTrees(trees);
   },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",
+    "broccoli-stew": "^1.5.0",
     "ember-cli-babel": "^5.1.7",
     "video.js": "^6.2.7"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1332,7 +1332,7 @@ broccoli-sri-hash@^2.1.0:
     sri-toolbox "^0.2.0"
     symlink-or-copy "^1.0.1"
 
-broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
+broccoli-stew@^1.2.0, broccoli-stew@^1.3.3, broccoli-stew@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.5.0.tgz#d7af8c18511dce510e49d308a62e5977f461883c"
   dependencies:
@@ -2076,7 +2076,7 @@ ember-cli-htmlbars-inline-precompile@^0.3.6:
     semver "^5.3.0"
     silent-error "^1.1.0"
 
-ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@^1.0.3, ember-cli-htmlbars@^1.1.1:
+ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@^1.1.1:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.4.tgz#461289724b34af372a6a0c4b6635819156963353"
   dependencies:
@@ -2451,14 +2451,6 @@ ember-try@^0.2.6:
     rimraf "^2.3.2"
     rsvp "^3.0.17"
     semver "^5.1.0"
-
-ember-welcome-page@^2.0.2:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/ember-welcome-page/-/ember-welcome-page-2.0.4.tgz#9506250cb5edc14449c8c294b2d4d3db27f615d3"
-  dependencies:
-    broccoli-funnel "^1.0.1"
-    ember-cli-babel "^5.1.6"
-    ember-cli-htmlbars "^1.0.3"
 
 encodeurl@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
-- Documenting how to include additional languages
-- Adding fastboot 1.0.0+ support based on (https://github.com/ember-fastboot/ember-cli-fastboot/issues/387) Closes #1 
-- Updated ember badge for 2.4+. This package doesn't test 1.x ember, and I'm guessing there isn't a lot of desire to do so.