### PR TITLE
Fix assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,9 +49,18 @@ module.exports = {
       trees.push(vendorTree);
     }
 
-    let videojsLib = new Funnel(path.join(path.dirname(require.resolve('video.js'))));
+    let src = path.join(path.dirname(require.resolve('video.js')));
+
+    let videojsLib = new Funnel(src, {
+      files: ['video.js', 'video.min.js', 'lang/*']
+    });
     videojsLib = map(videojsLib, (content) => `if (typeof FastBoot === 'undefined') { ${content} }`);
     trees.push(videojsLib);
+
+    let videojsAssets = new Funnel(src, {
+      exclude: ['video.js', 'video.min.js', 'lang/*']
+    });
+    trees.push(videojsAssets);
 
     return new MergeTrees(trees);
   },

--- a/index.js
+++ b/index.js
@@ -52,14 +52,17 @@ module.exports = {
     let src = path.join(path.dirname(require.resolve('video.js')));
 
     let videojsLib = new Funnel(src, {
-      files: ['video.js', 'video.min.js', 'lang/*']
+
+      include: ['lang/*', '*.js']
     });
+
     videojsLib = map(videojsLib, (content) => `if (typeof FastBoot === 'undefined') { ${content} }`);
     trees.push(videojsLib);
 
     let videojsAssets = new Funnel(src, {
-      exclude: ['video.js', 'video.min.js', 'lang/*']
+      exclude: ['lang/*', '*.js', '*.zip', 'examples', 'alt']
     });
+
     trees.push(videojsAssets);
 
     return new MergeTrees(trees);


### PR DESCRIPTION
There was an issue with the implementation of fastboot I wrote in the treeForVendor method. Originally I had it applied to the entire tree, which included non-js files. This resulted in the default styles provided by the videojs library not being pulled in.